### PR TITLE
Feature/admin tables

### DIFF
--- a/migrations/0001_friendly_hiroim.sql
+++ b/migrations/0001_friendly_hiroim.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "players" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text,
+	"nickname" text NOT NULL,
+	"tekken_id" text,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "players_nickname_unique" UNIQUE("nickname"),
+	CONSTRAINT "players_tekken_id_unique" UNIQUE("tekken_id")
+);
+--> statement-breakpoint
+CREATE INDEX "players_nickname_idx" ON "players" USING btree ("nickname");--> statement-breakpoint
+CREATE INDEX "players_tekken_id_idx" ON "players" USING btree ("tekken_id");

--- a/migrations/0002_aberrant_phantom_reporter.sql
+++ b/migrations/0002_aberrant_phantom_reporter.sql
@@ -1,0 +1,22 @@
+CREATE TYPE "public"."duel_status" AS ENUM('pending', 'completed', 'cancelled');--> statement-breakpoint
+CREATE TYPE "public"."winner" AS ENUM('player1', 'player2');--> statement-breakpoint
+CREATE TABLE "duels" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"player1_id" integer NOT NULL,
+	"player2_id" integer NOT NULL,
+	"player1_score" integer,
+	"player2_score" integer,
+	"referee_id" integer,
+	"video_url" text,
+	"status" "duel_status" DEFAULT 'pending' NOT NULL,
+	"winner" "winner",
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "duels" ADD CONSTRAINT "duels_player1_id_players_id_fk" FOREIGN KEY ("player1_id") REFERENCES "public"."players"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "duels" ADD CONSTRAINT "duels_player2_id_players_id_fk" FOREIGN KEY ("player2_id") REFERENCES "public"."players"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "duels" ADD CONSTRAINT "duels_referee_id_players_id_fk" FOREIGN KEY ("referee_id") REFERENCES "public"."players"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "duels_player1_id_idx" ON "duels" USING btree ("player1_id");--> statement-breakpoint
+CREATE INDEX "duels_player2_id_idx" ON "duels" USING btree ("player2_id");--> statement-breakpoint
+CREATE INDEX "duels_referee_id_idx" ON "duels" USING btree ("referee_id");

--- a/migrations/0003_blue_sunset_bain.sql
+++ b/migrations/0003_blue_sunset_bain.sql
@@ -1,0 +1,28 @@
+CREATE TYPE "public"."event_format" AS ENUM('ft10');--> statement-breakpoint
+CREATE TYPE "public"."event_status" AS ENUM('pending', 'completed', 'ongoing');--> statement-breakpoint
+CREATE TABLE "events" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"description_markdown" text,
+	"status" "event_status" DEFAULT 'pending' NOT NULL,
+	"start_date" timestamp NOT NULL,
+	"end_date" timestamp NOT NULL,
+	"format" "event_format" NOT NULL,
+	"winner_id" integer,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "events_players" (
+	"event_id" integer NOT NULL,
+	"player_id" integer NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "events_players_event_id_player_id_unique" UNIQUE("event_id","player_id")
+);
+--> statement-breakpoint
+ALTER TABLE "events" ADD CONSTRAINT "events_winner_id_players_id_fk" FOREIGN KEY ("winner_id") REFERENCES "public"."players"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "events_players" ADD CONSTRAINT "events_players_event_id_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "events_players" ADD CONSTRAINT "events_players_player_id_players_id_fk" FOREIGN KEY ("player_id") REFERENCES "public"."players"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "events_players_event_id_idx" ON "events_players" USING btree ("event_id");--> statement-breakpoint
+CREATE INDEX "events_players_player_id_idx" ON "events_players" USING btree ("player_id");

--- a/migrations/0004_parallel_blade.sql
+++ b/migrations/0004_parallel_blade.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "duels" ADD COLUMN "event_id" integer NOT NULL;--> statement-breakpoint
+ALTER TABLE "duels" ADD CONSTRAINT "duels_event_id_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE no action ON UPDATE no action;

--- a/migrations/meta/0001_snapshot.json
+++ b/migrations/meta/0001_snapshot.json
@@ -1,0 +1,471 @@
+{
+  "id": "c7b56499-58fb-43a8-908c-6d5337fd0ac6",
+  "prevId": "534249bb-a4f0-4693-abe6-4c4f3caf45e7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tekken_id": {
+          "name": "tekken_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "players_nickname_idx": {
+          "name": "players_nickname_idx",
+          "columns": [
+            {
+              "expression": "nickname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "players_tekken_id_idx": {
+          "name": "players_tekken_id_idx",
+          "columns": [
+            {
+              "expression": "tekken_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "players_nickname_unique": {
+          "name": "players_nickname_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nickname"
+          ]
+        },
+        "players_tekken_id_unique": {
+          "name": "players_tekken_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tekken_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/0002_snapshot.json
+++ b/migrations/meta/0002_snapshot.json
@@ -1,0 +1,659 @@
+{
+  "id": "5601ec5e-c400-4ce0-9590-e7c258e86950",
+  "prevId": "c7b56499-58fb-43a8-908c-6d5337fd0ac6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.duels": {
+      "name": "duels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player1_id": {
+          "name": "player1_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player2_id": {
+          "name": "player2_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player1_score": {
+          "name": "player1_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player2_score": {
+          "name": "player2_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referee_id": {
+          "name": "referee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "duel_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "winner": {
+          "name": "winner",
+          "type": "winner",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "duels_player1_id_idx": {
+          "name": "duels_player1_id_idx",
+          "columns": [
+            {
+              "expression": "player1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "duels_player2_id_idx": {
+          "name": "duels_player2_id_idx",
+          "columns": [
+            {
+              "expression": "player2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "duels_referee_id_idx": {
+          "name": "duels_referee_id_idx",
+          "columns": [
+            {
+              "expression": "referee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "duels_player1_id_players_id_fk": {
+          "name": "duels_player1_id_players_id_fk",
+          "tableFrom": "duels",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "duels_player2_id_players_id_fk": {
+          "name": "duels_player2_id_players_id_fk",
+          "tableFrom": "duels",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "duels_referee_id_players_id_fk": {
+          "name": "duels_referee_id_players_id_fk",
+          "tableFrom": "duels",
+          "tableTo": "players",
+          "columnsFrom": [
+            "referee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tekken_id": {
+          "name": "tekken_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "players_nickname_idx": {
+          "name": "players_nickname_idx",
+          "columns": [
+            {
+              "expression": "nickname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "players_tekken_id_idx": {
+          "name": "players_tekken_id_idx",
+          "columns": [
+            {
+              "expression": "tekken_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "players_nickname_unique": {
+          "name": "players_nickname_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nickname"
+          ]
+        },
+        "players_tekken_id_unique": {
+          "name": "players_tekken_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tekken_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.duel_status": {
+      "name": "duel_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.winner": {
+      "name": "winner",
+      "schema": "public",
+      "values": [
+        "player1",
+        "player2"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/0003_snapshot.json
+++ b/migrations/meta/0003_snapshot.json
@@ -1,0 +1,873 @@
+{
+  "id": "2f013238-3bd3-4d36-8e74-b1e94e627843",
+  "prevId": "5601ec5e-c400-4ce0-9590-e7c258e86950",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.duels": {
+      "name": "duels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player1_id": {
+          "name": "player1_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player2_id": {
+          "name": "player2_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player1_score": {
+          "name": "player1_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player2_score": {
+          "name": "player2_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referee_id": {
+          "name": "referee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "duel_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "winner": {
+          "name": "winner",
+          "type": "winner",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "duels_player1_id_idx": {
+          "name": "duels_player1_id_idx",
+          "columns": [
+            {
+              "expression": "player1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "duels_player2_id_idx": {
+          "name": "duels_player2_id_idx",
+          "columns": [
+            {
+              "expression": "player2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "duels_referee_id_idx": {
+          "name": "duels_referee_id_idx",
+          "columns": [
+            {
+              "expression": "referee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "duels_player1_id_players_id_fk": {
+          "name": "duels_player1_id_players_id_fk",
+          "tableFrom": "duels",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "duels_player2_id_players_id_fk": {
+          "name": "duels_player2_id_players_id_fk",
+          "tableFrom": "duels",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "duels_referee_id_players_id_fk": {
+          "name": "duels_referee_id_players_id_fk",
+          "tableFrom": "duels",
+          "tableTo": "players",
+          "columnsFrom": [
+            "referee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_markdown": {
+          "name": "description_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "event_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner_id": {
+          "name": "winner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_winner_id_players_id_fk": {
+          "name": "events_winner_id_players_id_fk",
+          "tableFrom": "events",
+          "tableTo": "players",
+          "columnsFrom": [
+            "winner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events_players": {
+      "name": "events_players",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_players_event_id_idx": {
+          "name": "events_players_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_players_player_id_idx": {
+          "name": "events_players_player_id_idx",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_players_event_id_events_id_fk": {
+          "name": "events_players_event_id_events_id_fk",
+          "tableFrom": "events_players",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_players_player_id_players_id_fk": {
+          "name": "events_players_player_id_players_id_fk",
+          "tableFrom": "events_players",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "events_players_event_id_player_id_unique": {
+          "name": "events_players_event_id_player_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "player_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tekken_id": {
+          "name": "tekken_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "players_nickname_idx": {
+          "name": "players_nickname_idx",
+          "columns": [
+            {
+              "expression": "nickname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "players_tekken_id_idx": {
+          "name": "players_tekken_id_idx",
+          "columns": [
+            {
+              "expression": "tekken_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "players_nickname_unique": {
+          "name": "players_nickname_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nickname"
+          ]
+        },
+        "players_tekken_id_unique": {
+          "name": "players_tekken_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tekken_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.duel_status": {
+      "name": "duel_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.winner": {
+      "name": "winner",
+      "schema": "public",
+      "values": [
+        "player1",
+        "player2"
+      ]
+    },
+    "public.event_format": {
+      "name": "event_format",
+      "schema": "public",
+      "values": [
+        "ft10"
+      ]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "ongoing"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/0004_snapshot.json
+++ b/migrations/meta/0004_snapshot.json
@@ -1,0 +1,892 @@
+{
+  "id": "2468f607-d6c8-4de4-91ed-65a3715ba7b8",
+  "prevId": "2f013238-3bd3-4d36-8e74-b1e94e627843",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.duels": {
+      "name": "duels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player1_id": {
+          "name": "player1_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player2_id": {
+          "name": "player2_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player1_score": {
+          "name": "player1_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player2_score": {
+          "name": "player2_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referee_id": {
+          "name": "referee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "duel_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "winner": {
+          "name": "winner",
+          "type": "winner",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "duels_player1_id_idx": {
+          "name": "duels_player1_id_idx",
+          "columns": [
+            {
+              "expression": "player1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "duels_player2_id_idx": {
+          "name": "duels_player2_id_idx",
+          "columns": [
+            {
+              "expression": "player2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "duels_referee_id_idx": {
+          "name": "duels_referee_id_idx",
+          "columns": [
+            {
+              "expression": "referee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "duels_player1_id_players_id_fk": {
+          "name": "duels_player1_id_players_id_fk",
+          "tableFrom": "duels",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "duels_player2_id_players_id_fk": {
+          "name": "duels_player2_id_players_id_fk",
+          "tableFrom": "duels",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "duels_event_id_events_id_fk": {
+          "name": "duels_event_id_events_id_fk",
+          "tableFrom": "duels",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "duels_referee_id_players_id_fk": {
+          "name": "duels_referee_id_players_id_fk",
+          "tableFrom": "duels",
+          "tableTo": "players",
+          "columnsFrom": [
+            "referee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_markdown": {
+          "name": "description_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "event_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner_id": {
+          "name": "winner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_winner_id_players_id_fk": {
+          "name": "events_winner_id_players_id_fk",
+          "tableFrom": "events",
+          "tableTo": "players",
+          "columnsFrom": [
+            "winner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events_players": {
+      "name": "events_players",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_players_event_id_idx": {
+          "name": "events_players_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_players_player_id_idx": {
+          "name": "events_players_player_id_idx",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_players_event_id_events_id_fk": {
+          "name": "events_players_event_id_events_id_fk",
+          "tableFrom": "events_players",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_players_player_id_players_id_fk": {
+          "name": "events_players_player_id_players_id_fk",
+          "tableFrom": "events_players",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "events_players_event_id_player_id_unique": {
+          "name": "events_players_event_id_player_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "player_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tekken_id": {
+          "name": "tekken_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "players_nickname_idx": {
+          "name": "players_nickname_idx",
+          "columns": [
+            {
+              "expression": "nickname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "players_tekken_id_idx": {
+          "name": "players_tekken_id_idx",
+          "columns": [
+            {
+              "expression": "tekken_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "players_nickname_unique": {
+          "name": "players_nickname_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nickname"
+          ]
+        },
+        "players_tekken_id_unique": {
+          "name": "players_tekken_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tekken_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.duel_status": {
+      "name": "duel_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.winner": {
+      "name": "winner",
+      "schema": "public",
+      "values": [
+        "player1",
+        "player2"
+      ]
+    },
+    "public.event_format": {
+      "name": "event_format",
+      "schema": "public",
+      "values": [
+        "ft10"
+      ]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "ongoing"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1769109949510,
       "tag": "0001_friendly_hiroim",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1769119056340,
+      "tag": "0002_aberrant_phantom_reporter",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1769120490493,
       "tag": "0003_blue_sunset_bain",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1769121043031,
+      "tag": "0004_parallel_blade",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1768862419990,
       "tag": "0000_next_killraven",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1769109949510,
+      "tag": "0001_friendly_hiroim",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1769119056340,
       "tag": "0002_aberrant_phantom_reporter",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1769120490493,
+      "tag": "0003_blue_sunset_bain",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/duels-schema.ts
+++ b/src/db/schema/duels-schema.ts
@@ -2,9 +2,8 @@ import { pgTable, text, index, serial, pgEnum, integer } from "drizzle-orm/pg-co
 
 import { timestamps } from "./utils";
 import { players } from "./players-schema";
+import { events } from "./event-schema";
 
-// Define the enum first - this will be created before the table
-// Remember to update the schema.graphql and resolvers mapping
 export const winnerEnum = pgEnum('winner', [
   'player1', 'player2'
 ]);
@@ -20,6 +19,7 @@ export const duels = pgTable("duels", {
   id: serial("id").primaryKey(),
   player1Id: integer("player1_id").references(() => players.id).notNull(),
   player2Id: integer("player2_id").references(() => players.id).notNull(),
+  eventId: integer("event_id").references(() => events.id).notNull(),
   player1Score: integer("player1_score"),
   player2Score: integer("player2_score"),
   // Referee is optional

--- a/src/db/schema/duels-schema.ts
+++ b/src/db/schema/duels-schema.ts
@@ -13,6 +13,9 @@ export const duelStatusEnum = pgEnum('duel_status', [
   'pending', 'completed', 'cancelled'
 ]);
 
+export type DuelWinner = (typeof winnerEnum.enumValues)[number];
+export type DuelStatus = (typeof duelStatusEnum.enumValues)[number];
+
 export const duels = pgTable("duels", {
   id: serial("id").primaryKey(),
   player1Id: integer("player1_id").references(() => players.id).notNull(),

--- a/src/db/schema/duels-schema.ts
+++ b/src/db/schema/duels-schema.ts
@@ -1,0 +1,33 @@
+import { pgTable, text, index, serial, pgEnum, integer } from "drizzle-orm/pg-core";
+
+import { timestamps } from "./utils";
+import { players } from "./players-schema";
+
+// Define the enum first - this will be created before the table
+// Remember to update the schema.graphql and resolvers mapping
+export const winnerEnum = pgEnum('winner', [
+  'player1', 'player2'
+]);
+
+export const duelStatusEnum = pgEnum('duel_status', [
+  'pending', 'completed', 'cancelled'
+]);
+
+export const duels = pgTable("duels", {
+  id: serial("id").primaryKey(),
+  player1Id: integer("player1_id").references(() => players.id).notNull(),
+  player2Id: integer("player2_id").references(() => players.id).notNull(),
+  player1Score: integer("player1_score"),
+  player2Score: integer("player2_score"),
+  // Referee is optional
+  refereeId: integer("referee_id").references(() => players.id),
+
+  videoUrl: text("video_url"),
+  status: duelStatusEnum("status").default("pending").notNull(),
+  winner: winnerEnum("winner"),
+  ...timestamps,
+}, (table) => [
+  index("duels_player1_id_idx").on(table.player1Id),
+  index("duels_player2_id_idx").on(table.player2Id),
+  index("duels_referee_id_idx").on(table.refereeId),
+]);

--- a/src/db/schema/event-schema.ts
+++ b/src/db/schema/event-schema.ts
@@ -1,0 +1,35 @@
+import { pgTable, text, index, serial, pgEnum, integer, timestamp, unique } from "drizzle-orm/pg-core";
+
+import { timestamps } from "./utils";
+import { players } from "./players-schema";
+
+export const eventStatusEnum = pgEnum('event_status', ['pending', 'completed', 'ongoing']);
+export const eventFormatEnum = pgEnum('event_format', ['ft10']);
+
+export type EventStatus = (typeof eventStatusEnum.enumValues)[number];
+export type EventFormat = (typeof eventFormatEnum.enumValues)[number];
+
+export const events = pgTable("events", {
+  id: serial("id").primaryKey(),
+  name: text("name").notNull(),
+  descriptionMarkdown: text("description_markdown"),
+  status: eventStatusEnum("status").default("pending").notNull(),
+  startDate: timestamp("start_date").notNull(),
+  endDate: timestamp("end_date").notNull(),
+  format: eventFormatEnum("format").notNull(),
+  winnerId: integer("winner_id").references(() => players.id),
+  ...timestamps,
+})
+
+// EventsXPlayers
+
+export const eventsPlayers = pgTable("events_players", {
+  eventId: integer("event_id").references(() => events.id).notNull(),
+  playerId: integer("player_id").references(() => players.id).notNull(),
+  ...timestamps,
+}, (table) => [
+  index("events_players_event_id_idx").on(table.eventId),
+  index("events_players_player_id_idx").on(table.playerId),
+  // Unique constraint: a player can only participate once per event
+  unique().on(table.eventId, table.playerId),
+]);

--- a/src/db/schema/players-schema.ts
+++ b/src/db/schema/players-schema.ts
@@ -1,0 +1,17 @@
+import { pgTable, text, timestamp, index, serial } from "drizzle-orm/pg-core";
+
+const timestamps = {
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+}
+
+export const user = pgTable("players", {
+  id: serial("id").primaryKey(),
+  name: text("name"),
+  nickname: text("nickname").notNull().unique(),
+  tekken_id: text("tekken_id").unique(),
+  ...timestamps,
+}, (table) => [
+  index("players_nickname_idx").on(table.nickname),
+  index("players_tekken_id_idx").on(table.tekken_id),
+]);

--- a/src/db/schema/players-schema.ts
+++ b/src/db/schema/players-schema.ts
@@ -5,13 +5,13 @@ const timestamps = {
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
 }
 
-export const user = pgTable("players", {
+export const players = pgTable("players", {
   id: serial("id").primaryKey(),
   name: text("name"),
   nickname: text("nickname").notNull().unique(),
-  tekken_id: text("tekken_id").unique(),
+  tekkenId: text("tekken_id").unique(),
   ...timestamps,
 }, (table) => [
   index("players_nickname_idx").on(table.nickname),
-  index("players_tekken_id_idx").on(table.tekken_id),
+  index("players_tekken_id_idx").on(table.tekkenId),
 ]);

--- a/src/db/schema/utils.ts
+++ b/src/db/schema/utils.ts
@@ -1,0 +1,6 @@
+import { timestamp } from "drizzle-orm/pg-core";
+
+export const timestamps = {
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+}

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -179,6 +179,7 @@ async function seedDuels() {
     const [player1] = await db.select().from(players).where(eq(players.nickname, "KingWilly")).limit(1);
     const [player2] = await db.select().from(players).where(eq(players.nickname, "MichiMishima")).limit(1);
     const [player3] = await db.select().from(players).where(eq(players.nickname, "John Doe")).limit(1);
+    const [event] = await db.select().from(events).where(eq(events.name, "Liga Demo")).limit(1);
 
     if (!player1 || !player2 || !player3) {
       throw new Error("Required players not found. Make sure players are seeded first.");
@@ -193,6 +194,7 @@ async function seedDuels() {
         status: "completed" as DuelStatus,
         winner: "player1" as DuelWinner,
         refereeId: player3.id, // John Doe as referee
+        eventId: event.id,
       },
       {
         player1Id: player2.id,
@@ -202,6 +204,7 @@ async function seedDuels() {
         status: "completed" as DuelStatus,
         winner: "player2" as DuelWinner,
         // No referee for this one
+        eventId: event.id,
       },
     ];
 
@@ -279,8 +282,8 @@ async function seed() {
   try {
     await seedUsers();
     await seedPlayers();
-    await seedDuels();
     await seedEvents();
+    await seedDuels(); // Duels require events and players to be seeded first
     console.log("\n🎉 All seeding completed successfully!");
   } catch (error) {
     console.error("❌ Error seeding database:", error);

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -3,6 +3,8 @@ import { auth } from "@/lib/auth";
 
 import { db } from "@/db/drizzle";
 import { players } from "@/db/schema/players-schema";
+import { duels, type DuelWinner, DuelStatus } from "@/db/schema/duels-schema";
+import { eq } from "drizzle-orm";
 
 /**
  * Seed script for better-auth
@@ -137,10 +139,75 @@ async function seedPlayers() {
   }
 }
 
+// =============================== Duels ===============================
+
+async function seedDuels() {
+  console.log("\n🌱 Seeding duels...");
+
+  try {
+    // First, get player IDs by querying their nicknames
+    const [player1] = await db.select().from(players).where(eq(players.nickname, "KingWilly")).limit(1);
+    const [player2] = await db.select().from(players).where(eq(players.nickname, "MichiMishima")).limit(1);
+    const [player3] = await db.select().from(players).where(eq(players.nickname, "John Doe")).limit(1);
+
+    if (!player1 || !player2 || !player3) {
+      throw new Error("Required players not found. Make sure players are seeded first.");
+    }
+
+    const testDuels = [
+      {
+        player1Id: player1.id,
+        player2Id: player2.id,
+        player1Score: 10,
+        player2Score: 3,
+        status: "completed" as DuelStatus,
+        winner: "player1" as DuelWinner,
+        refereeId: player3.id, // John Doe as referee
+      },
+      {
+        player1Id: player2.id,
+        player2Id: player3.id,
+        player1Score: 2,
+        player2Score: 10,
+        status: "completed" as DuelStatus,
+        winner: "player2" as DuelWinner,
+        // No referee for this one
+      },
+    ];
+
+    let created = 0;
+    let skipped = 0;
+
+    for (const duel of testDuels) {
+      try {
+        await db.insert(duels).values(duel);
+        console.log(`  ✓ Created duel: ${duel.player1Id} vs ${duel.player2Id} (Winner: ${duel.winner})`);
+        created++;
+      } catch (error: any) {
+        // Check both error.code and error.cause.code (Drizzle wraps PostgreSQL errors)
+        const errorCode = error?.code || error?.cause?.code;
+        if (errorCode === "23505") {
+          // PostgreSQL unique violation error code
+          console.log(`  ⊘ Skipped duel (already exists): ${duel.player1Id} vs ${duel.player2Id}`);
+          skipped++;
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    console.log(`✅ Duels seeding completed! Created: ${created}, Skipped: ${skipped}`);
+  } catch (error) {
+    console.error("❌ Error seeding duels:", error);
+    throw error; // Re-throw to be caught by main seed function
+  }
+}
+
 async function seed() {
   try {
     await seedUsers();
     await seedPlayers();
+    await seedDuels();
     console.log("\n🎉 All seeding completed successfully!");
   } catch (error) {
     console.error("❌ Error seeding database:", error);

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -19,6 +19,44 @@ import { eq } from "drizzle-orm";
  * better-auth hashes passwords using bcrypt, so we must use its API to create users.
  */
 
+/**
+ * Generic helper function to seed records with duplicate handling
+ * @param items Array of items to seed
+ * @param insertFn Function that inserts a single item
+ * @param getIdentifier Function that returns a string identifier for logging (e.g., nickname, email)
+ * @param entityName Name of the entity for logging (e.g., "player", "duel")
+ * @returns Object with created and skipped counts
+ */
+async function seedRecords<T>(
+  items: T[],
+  insertFn: (item: T) => Promise<unknown>,
+  getIdentifier: (item: T) => string,
+  entityName: string
+): Promise<{ created: number; skipped: number }> {
+  let created = 0;
+  let skipped = 0;
+
+  for (const item of items) {
+    try {
+      await insertFn(item);
+      console.log(`  ✓ Created ${entityName}: ${getIdentifier(item)}`);
+      created++;
+    } catch (error: any) {
+      // Check both error.code and error.cause.code (Drizzle wraps PostgreSQL errors)
+      const errorCode = error?.code || error?.cause?.code;
+      if (errorCode === "23505") {
+        // PostgreSQL unique violation error code
+        console.log(`  ⊘ Skipped ${entityName} (already exists): ${getIdentifier(item)}`);
+        skipped++;
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  return { created, skipped };
+}
+
 async function seedUsers() {
   console.log("🌱 Seeding database...");
 
@@ -111,26 +149,12 @@ async function seedPlayers() {
       }
     ];
 
-    let created = 0;
-    let skipped = 0;
-
-    for (const player of testPlayers) {
-      try {
-        await db.insert(players).values(player);
-        console.log(`  ✓ Created player: ${player.nickname}`);
-        created++;
-      } catch (error: any) {
-        // Check both error.code and error.cause.code (Drizzle wraps PostgreSQL errors)
-        const errorCode = error?.code || error?.cause?.code;
-        if (errorCode === "23505") {
-          // PostgreSQL unique violation error code
-          console.log(`  ⊘ Skipped player (already exists): ${player.nickname}`);
-          skipped++;
-        } else {
-          throw error;
-        }
-      }
-    }
+    const { created, skipped } = await seedRecords(
+      testPlayers,
+      (player) => db.insert(players).values(player),
+      (player) => player.nickname,
+      "player"
+    );
 
     console.log(`✅ Players seeding completed! Created: ${created}, Skipped: ${skipped}`);
   } catch (error) {
@@ -175,26 +199,12 @@ async function seedDuels() {
       },
     ];
 
-    let created = 0;
-    let skipped = 0;
-
-    for (const duel of testDuels) {
-      try {
-        await db.insert(duels).values(duel);
-        console.log(`  ✓ Created duel: ${duel.player1Id} vs ${duel.player2Id} (Winner: ${duel.winner})`);
-        created++;
-      } catch (error: any) {
-        // Check both error.code and error.cause.code (Drizzle wraps PostgreSQL errors)
-        const errorCode = error?.code || error?.cause?.code;
-        if (errorCode === "23505") {
-          // PostgreSQL unique violation error code
-          console.log(`  ⊘ Skipped duel (already exists): ${duel.player1Id} vs ${duel.player2Id}`);
-          skipped++;
-        } else {
-          throw error;
-        }
-      }
-    }
+    const { created, skipped } = await seedRecords(
+      testDuels,
+      (duel) => db.insert(duels).values(duel),
+      (duel) => `${duel.player1Id} vs ${duel.player2Id} (Winner: ${duel.winner})`,
+      "duel"
+    );
 
     console.log(`✅ Duels seeding completed! Created: ${created}, Skipped: ${skipped}`);
   } catch (error) {

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -6,6 +6,12 @@ import { players } from "@/db/schema/players-schema";
 import { duels, type DuelWinner, DuelStatus } from "@/db/schema/duels-schema";
 import { eq } from "drizzle-orm";
 
+import {
+  events,
+  eventsPlayers,
+  type EventFormat
+} from "@/db/schema/event-schema";
+
 /**
  * Seed script for better-auth
  * 
@@ -213,11 +219,68 @@ async function seedDuels() {
   }
 }
 
+async function seedEvents() {
+  console.log("\n🌱 Seeding events...");
+
+  try {
+    const testEvents = [
+      {
+        name: "Liga Demo",
+        descriptionMarkdown: `
+        # Liga Demo
+        ## Descripción
+        Esta es una liga demo con descripción por markdown
+        * Regla 1
+        * Regla 2
+        `,
+        startDate: new Date("2026-01-01"),
+        endDate: new Date("2026-06-01"),
+        format: "ft10" as EventFormat,
+      }
+    ];
+
+    const { created, skipped } = await seedRecords(
+      testEvents,
+      (event) => db.insert(events).values(event),
+      (event) => event.name,
+      "event"
+    );
+    
+    console.log(`✅ Events seeding completed! Created: ${created}, Skipped: ${skipped}`);
+
+    // EventsXPlayers (make first 3 players participate in the event)
+    const [event] = await db.select().from(events).where(eq(events.name, "Liga Demo")).limit(1);
+
+    const participants = await db.select().from(players).limit(3);
+    if (!participants || participants.length !== 3) {
+      throw new Error("Required players not found. Make sure players are seeded first.");
+    }
+
+    const participantsItems = participants.map(participant => ({
+      eventId: event.id,
+      playerId: participant.id,
+    }));
+
+    const { created: createdEventsPlayers, skipped: skippedEventsPlayers } = await seedRecords(
+      participantsItems,
+      (eventPlayer) => db.insert(eventsPlayers).values(eventPlayer),
+      (eventPlayer) => `${eventPlayer.eventId} - ${eventPlayer.playerId}`,
+      "event_player"
+    );
+    
+    console.log(`✅ EventsXPlayers seeding completed! Created: ${createdEventsPlayers}, Skipped: ${skippedEventsPlayers}`);
+  } catch (error) {
+    console.error("❌ Error seeding events:", error);
+    throw error; // Re-throw to be caught by main seed function
+  }
+}
+
 async function seed() {
   try {
     await seedUsers();
     await seedPlayers();
     await seedDuels();
+    await seedEvents();
     console.log("\n🎉 All seeding completed successfully!");
   } catch (error) {
     console.error("❌ Error seeding database:", error);

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -1,6 +1,9 @@
 import "dotenv/config";
 import { auth } from "@/lib/auth";
 
+import { db } from "@/db/drizzle";
+import { players } from "@/db/schema/players-schema";
+
 /**
  * Seed script for better-auth
  * 
@@ -14,10 +17,10 @@ import { auth } from "@/lib/auth";
  * better-auth hashes passwords using bcrypt, so we must use its API to create users.
  */
 
-async function seed() {
+async function seedUsers() {
   console.log("🌱 Seeding database...");
 
-  // =============================== Users with Passwords ==================================================================================
+  // =============================== Users with Passwords ===============================
   try {
     // Test users to create
     // Using better-auth's API ensures passwords are properly hashed
@@ -74,11 +77,71 @@ async function seed() {
       }
     }
 
-    console.log(`\n✅ Seeding completed! Created: ${created}, Skipped: ${skipped}`);
+    console.log(`✅ Users seeding completed! Created: ${created}, Skipped: ${skipped}`);
     console.log(`\n📝 Test credentials:`);
     testUsers.forEach(u => {
       console.log(`   ${u.email} / ${u.password}`);
     });
+  } catch (error) {
+    console.error("❌ Error seeding users:", error);
+    throw error; // Re-throw to be caught by main seed function
+  }
+}
+
+// =============================== Players ===============================
+
+async function seedPlayers() {
+  console.log("\n🌱 Seeding players...");
+
+  try {
+    const testPlayers = [
+      {
+        name: "Willy",
+        nickname: "KingWilly",
+        tekkenId: "1234567890",
+      },
+      {
+        name: "Michi",
+        nickname: "MichiMishima",
+      },
+      {
+        nickname: "John Doe"
+      }
+    ];
+
+    let created = 0;
+    let skipped = 0;
+
+    for (const player of testPlayers) {
+      try {
+        await db.insert(players).values(player);
+        console.log(`  ✓ Created player: ${player.nickname}`);
+        created++;
+      } catch (error: any) {
+        // Check both error.code and error.cause.code (Drizzle wraps PostgreSQL errors)
+        const errorCode = error?.code || error?.cause?.code;
+        if (errorCode === "23505") {
+          // PostgreSQL unique violation error code
+          console.log(`  ⊘ Skipped player (already exists): ${player.nickname}`);
+          skipped++;
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    console.log(`✅ Players seeding completed! Created: ${created}, Skipped: ${skipped}`);
+  } catch (error) {
+    console.error("❌ Error seeding players:", error);
+    throw error; // Re-throw to be caught by main seed function
+  }
+}
+
+async function seed() {
+  try {
+    await seedUsers();
+    await seedPlayers();
+    console.log("\n🎉 All seeding completed successfully!");
   } catch (error) {
     console.error("❌ Error seeding database:", error);
     process.exit(1);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Establishes core competitive data model and seeds realistic test data.
> 
> - New tables: `players`, `events`, `events_players` (unique `event_id+player_id`), and `duels`; adds enums `event_status`, `event_format`, `duel_status`, `winner`
> - Adds FKs and indexes linking `duels` to `players` and `events` (adds `duels.event_id`) and `events` winner to `players`
> - Introduces Drizzle schemas for `players`, `events`/`events_players`, and `duels` with shared `timestamps`
> - Refactors seed script: generic `seedRecords` helper and ordered seeding of users, players, events (with participants), and duels
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56a0bc828320b9aafafa3e713d3381d87768358b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->